### PR TITLE
[FIX] account_invoice_transmit_peppol: Sent invoice one by one by peppol

### DIFF
--- a/account_invoice_transmit_peppol/data/queue_job_functions.xml
+++ b/account_invoice_transmit_peppol/data/queue_job_functions.xml
@@ -3,11 +3,22 @@
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
 
+<record id="job_function_batch_send_invoice_peppol" model="queue.job.function">
+    <field name="model_id" ref="account.model_account_move" />
+    <field name="method">_batch_transmit_invoice_by_peppol</field>
+    <field name="channel_id" ref="invoice_transmit_peppol" />
+    <field
+      name="related_action"
+      eval='{"func_name": "related_action_open_invoice"}'
+    />
+</record>
 <record id="job_function_send_invoice_peppol" model="queue.job.function">
     <field name="model_id" ref="account.model_account_move" />
     <field name="method">_transmit_invoice_by_peppol</field>
     <field name="channel_id" ref="invoice_transmit_peppol" />
-    <field name="related_action" eval='{"func_name": "related_action_open_invoice"}' />
+    <field
+      name="related_action"
+      eval='{"func_name": "related_action_open_invoice"}'
+    />
 </record>
-
 </odoo>

--- a/account_invoice_transmit_peppol/models/account_move.py
+++ b/account_invoice_transmit_peppol/models/account_move.py
@@ -1,13 +1,37 @@
 # Copyright 2023 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import _, models
+from odoo.addons.queue_job.job import identity_exact
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
+    def _batch_transmit_invoice_by_peppol(self):
+        """Mass sending by peppol
+
+        Since sending by Peppol can be time consuming due to the
+        communication with external services, we create a separate
+        job for each invoice.
+
+        """
+        result = []
+        for invoice in self:
+            description = _(
+                "Generating invoice for peppol sending: %(name)s",
+                name=invoice.display_name,
+            )
+            invoice.with_delay(
+                description=description,
+                identity_key=identity_exact,
+                priority=40,
+                channel="root.invoice_transmit.peppol",
+            )._transmit_invoice_by_peppol()
+            result.append(description)
+        return "\n".join(result)
+
     def _transmit_invoice_by_peppol(self):
-        """Mass sending by peppol"""
+        """Sending by peppol"""
         invoices = self._transmit_invoice("peppol")
         return invoices.peppol_export_invoice()

--- a/account_invoice_transmit_peppol/wizards/account_invoice_transmit.py
+++ b/account_invoice_transmit_peppol/wizards/account_invoice_transmit.py
@@ -44,7 +44,7 @@ class AccountInvoiceSent(models.TransientModel):
             identity_key=identity_exact,
             priority=40,
             channel="root.invoice_transmit.peppol",
-        )._transmit_invoice_by_peppol()
+        )._batch_transmit_invoice_by_peppol()
         self.env.user.notify_info(
             _("Invoices will be sent by peppol in the background.")
         )


### PR DESCRIPTION
This is required to avoid locking the system when hundreds of invoices are sent at same time...