### PR TITLE
[IMP] account_invoice_export_ubl: catch network failure & retry in case async

### DIFF
--- a/account_invoice_export_ubl/models/account_invoice.py
+++ b/account_invoice_export_ubl/models/account_invoice.py
@@ -7,6 +7,8 @@ from lxml import etree
 from odoo import _, fields, models
 from odoo.exceptions import UserError, except_orm
 
+from .peppol_server import PeppolTemporaryNetworkError
+
 
 class AccountMove(models.Model):
     _inherit = "account.move"
@@ -28,6 +30,10 @@ class AccountMove(models.Model):
                 invoice._peppol_export_invoice()
                 invoice._peppol_sending_log_success()
             except Exception as e:
+                if isinstance(e, PeppolTemporaryNetworkError) and self.env.context.get(
+                    "peppol_raise_temporary_network_errors"
+                ):
+                    raise
                 invoices_in_error |= invoice
                 values = {
                     "error_detail": "",

--- a/account_invoice_export_ubl/models/peppol_server.py
+++ b/account_invoice_export_ubl/models/peppol_server.py
@@ -9,6 +9,12 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from requests.auth import HTTPBasicAuth
 
+TEMPORARY_NETWORK_ERROR_CODES = {502, 503}
+
+
+class PeppolTemporaryNetworkError(Exception):
+    pass
+
 
 class PeppolServer(models.Model):
     _name = "peppol.server"
@@ -47,6 +53,14 @@ class PeppolServer(models.Model):
         self.ensure_one()
         file_data = {"file": ubl}
         response = requests.post(self.url.lower(), auth=self._auth(), files=file_data)
+        if response.status_code in TEMPORARY_NETWORK_ERROR_CODES:
+            raise PeppolTemporaryNetworkError(
+                _(
+                    "HTTP error {} sending UBL: {}".format(
+                        response.status_code, response.text
+                    )
+                )
+            )
         if response.status_code != 200:
             raise UserError(
                 _(

--- a/account_invoice_export_ubl/tests/test_export.py
+++ b/account_invoice_export_ubl/tests/test_export.py
@@ -89,6 +89,72 @@ class TestExportUbl(BaseCommon):
             invoice.peppol_export_invoice()
         self.assertFalse(invoice.is_move_sent)
 
+    def test_export_network_failure_logs_invoice_error_without_context(self):
+        with Form(
+            self.env["account.move"].with_context(default_move_type="out_invoice")
+        ) as invoice_form:
+            invoice_form.partner_id = self.partner
+            with invoice_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = self.product
+        invoice = invoice_form.save()
+
+        invoice.invoice_line_ids.tax_ids.unece_type_id = self.vat_type
+        invoice.invoice_line_ids.tax_ids.unece_categ_id = self.vat_categ
+        invoice._post()
+
+        response = Response()
+        response.status_code = 503
+        response._content = b"Service Unavailable"
+        with (
+            mock.patch("requests.post") as post_mock,
+            mock.patch.object(
+                type(invoice), "_peppol_sending_log_error"
+            ) as log_error,
+            self.assertRaisesRegex(UserError, "Peppol sending failed for"),
+        ):
+            post_mock.return_value = response
+            invoice.peppol_export_invoice()
+        log_error.assert_called_once()
+        self.assertFalse(invoice.is_move_sent)
+        self.assertFalse(invoice.invoice_exported)
+        self.assertFalse(invoice.invoice_export_confirmed)
+
+    def test_export_network_failure_raises_original_error_with_context(self):
+        with Form(
+            self.env["account.move"].with_context(default_move_type="out_invoice")
+        ) as invoice_form:
+            invoice_form.partner_id = self.partner
+            with invoice_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = self.product
+        invoice = invoice_form.save()
+
+        invoice.invoice_line_ids.tax_ids.unece_type_id = self.vat_type
+        invoice.invoice_line_ids.tax_ids.unece_categ_id = self.vat_categ
+        invoice._post()
+
+        for status_code in (502, 503):
+            with self.subTest(status_code=status_code):
+                response = Response()
+                response.status_code = status_code
+                response._content = b"Service Unavailable"
+                with (
+                    mock.patch("requests.post") as post_mock,
+                    mock.patch.object(
+                        type(invoice), "_peppol_sending_log_error"
+                    ) as log_error,
+                    self.assertRaisesRegex(
+                        Exception, f"HTTP error {status_code} sending UBL"
+                    ),
+                ):
+                    post_mock.return_value = response
+                    invoice.with_context(
+                        peppol_raise_temporary_network_errors=True
+                    ).peppol_export_invoice()
+                log_error.assert_not_called()
+        self.assertFalse(invoice.is_move_sent)
+        self.assertFalse(invoice.invoice_exported)
+        self.assertFalse(invoice.invoice_export_confirmed)
+
     def test_status_error(self):
         with Form(
             self.env["account.move"].with_context(default_move_type="out_invoice")

--- a/account_invoice_transmit_peppol/models/account_move.py
+++ b/account_invoice_transmit_peppol/models/account_move.py
@@ -2,6 +2,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, models
+from odoo.addons.account_invoice_export_ubl.models.peppol_server import (
+    PeppolTemporaryNetworkError,
+)
+from odoo.addons.queue_job.exception import RetryableJobError
 from odoo.addons.queue_job.job import identity_exact
 
 
@@ -34,4 +38,9 @@ class AccountMove(models.Model):
     def _transmit_invoice_by_peppol(self):
         """Sending by peppol"""
         invoices = self._transmit_invoice("peppol")
-        return invoices.peppol_export_invoice()
+        try:
+            return invoices.with_context(
+                peppol_raise_temporary_network_errors=True
+            ).peppol_export_invoice()
+        except PeppolTemporaryNetworkError as e:
+            raise RetryableJobError(str(e)) from e

--- a/account_invoice_transmit_peppol/tests/__init__.py
+++ b/account_invoice_transmit_peppol/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_transmit_invoice_peppol

--- a/account_invoice_transmit_peppol/tests/test_transmit_invoice_peppol.py
+++ b/account_invoice_transmit_peppol/tests/test_transmit_invoice_peppol.py
@@ -1,0 +1,73 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import mock
+from odoo.fields import Command
+from odoo.tests import tagged
+from requests import Response
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.queue_job.exception import RetryableJobError
+
+
+@tagged("-at_install", "post_install")
+class TestTransmitInvoicePeppol(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = cls.env.ref("product.product_product_4")
+        cls.peppol = cls.env.ref("account_invoice_transmit_peppol.peppol")
+        cls.vat_type = cls.env.ref("account_tax_unece.tax_type_vat")
+        cls.vat_categ = cls.env.ref("account_tax_unece.tax_categ_s")
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Peppol Customer",
+                "customer_invoice_transmit_method_id": cls.peppol.id,
+            }
+        )
+        cls.peppol_server = cls.env["peppol.server"].create(
+            {
+                "name": "Test",
+                "account_user": "test",
+                "account_password": "test",
+            }
+        )
+        cls.env.company.peppol_server_id = cls.peppol_server
+
+    def _create_invoice(self):
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.partner.id,
+                "move_type": "out_invoice",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "test peppol",
+                            "price_unit": 100.0,
+                            "quantity": 1,
+                            "product_id": self.product.id,
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.invoice_line_ids.tax_ids.unece_type_id = self.vat_type
+        invoice.invoice_line_ids.tax_ids.unece_categ_id = self.vat_categ
+        invoice.action_post()
+        return invoice
+
+    def test_temporary_network_failure_is_retryable(self):
+        invoice = self._create_invoice()
+
+        response = Response()
+        response.status_code = 503
+        response._content = b"Service Unavailable"
+        with mock.patch("requests.post") as post_mock:
+            post_mock.return_value = response
+            with self.assertRaisesRegex(
+                RetryableJobError,
+                "HTTP error 503 sending UBL: Service Unavailable",
+            ):
+                with self.env.cr.savepoint():
+                    invoice._transmit_invoice_by_peppol()
+        post_mock.assert_called_once()


### PR DESCRIPTION
when the peppol server returns a temporary HTTP 503 error, the original
network failure should be propagated to the caller instead of being swallowed
and replaced by the generic invoice error

this is useful for async invoice sending, the error must be handled by
queue_job for retry instead of being logged on the invoice while the job is
marked as done

@jbaudoux, @rousseldenis , @lmignon 